### PR TITLE
Update x86 macOS runner to 11.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       BUILD_TYPE: ${{ matrix.type }}
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: 'crashpad/crashpad'
 
@@ -69,7 +69,7 @@ jobs:
       matrix:
         include:
           - arch: x86_64
-            os: macos-10.15
+            os: macos-11.0
           - arch: arm64
             os: macos-11.0
     name: macOS (${{ matrix.arch }})
@@ -83,7 +83,7 @@ jobs:
       BUILD_TYPE: ${{ matrix.type }}
     steps:
       - name: Checkout Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: 'crashpad/crashpad'
 


### PR DESCRIPTION
macOS 10.15 runners will be unsupported in a month

Update checkout action to hopefully get rid of ::set-output deprecation warnings